### PR TITLE
Check for computed instance properties (test only)

### DIFF
--- a/packages/babel-polyfill-provider-corejs3/test/fixtures/usage-pure/instance-computed/input.js
+++ b/packages/babel-polyfill-provider-corejs3/test/fixtures/usage-pure/instance-computed/input.js
@@ -1,0 +1,4 @@
+var filter = 'foo';
+var bar = { foo: function() { return 'foo'; }}
+
+bar[filter]();

--- a/packages/babel-polyfill-provider-corejs3/test/fixtures/usage-pure/instance-computed/options.json
+++ b/packages/babel-polyfill-provider-corejs3/test/fixtures/usage-pure/instance-computed/options.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    [
+      "@babel/plugin-inject-polyfills",
+      {
+        "method": "usage-pure",
+        "providers": ["@@/corejs3"]
+      }
+    ]
+  ]
+}

--- a/packages/babel-polyfill-provider-corejs3/test/fixtures/usage-pure/instance-computed/output.js
+++ b/packages/babel-polyfill-provider-corejs3/test/fixtures/usage-pure/instance-computed/output.js
@@ -1,0 +1,7 @@
+var filter = 'foo';
+var bar = {
+  foo: function () {
+    return 'foo';
+  }
+};
+bar[filter]();


### PR DESCRIPTION
Tried to port https://github.com/babel/babel/pull/10207, but the test case was already covered by the current code. Ended up including a test only.