### PR TITLE
Add a `shouldInjectPolyfill` option to polyfill providers

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -62,6 +62,18 @@ See the same options at https://babeljs.io/docs/en/babel-preset-env
 
 ## Advanced options
 
+### `shouldInjectPolyfill`
+
+`include` and `exclude` are great ways to forcefully mark a given polyfill as supported or unsupported.
+
+However, sometimes you might need something mroe advanced or customized: for example, you could want to store somewhere a list of the injected polyfills, or to throw an error when a given polyfill would be included.
+
+The `shouldInjectPolyfill` function takes two parameters: the name of the polyfill and wether or not it should be injected based on your targets. It must return a boolean, indicating wether or not the polyfill should be injected.
+
+```js
+function shouldInjectPolyfill(name: string, defaultShouldInject: boolean): boolean;
+```
+
 ### `missingDependencies`
 
 This option modifies the dependencies detection logging. If set to `false`, dependencies

--- a/packages/babel-helper-define-polyfill-provider/src/types.js
+++ b/packages/babel-helper-define-polyfill-provider/src/types.js
@@ -31,6 +31,7 @@ export type PluginOptions = {|
   debug?: boolean,
   include?: Pattern[],
   exclude?: Pattern[],
+  shouldInjectPolyfill?: (name: string, shouldInject: boolean) => boolean,
   missingDependencies?: MissingDependenciesOption,
 |};
 

--- a/packages/babel-helper-define-polyfill-provider/test/options.js
+++ b/packages/babel-helper-define-polyfill-provider/test/options.js
@@ -1,15 +1,15 @@
 import * as babel from "@babel/core";
 import definePolyfillProvider from "../lib";
 
-function transform(code, method, obj) {
+function transform(code, opts, provider) {
   return babel.transformSync(code, {
     configFile: false,
-    plugins: [[definePolyfillProvider(() => obj), { method }]],
+    plugins: [[definePolyfillProvider(provider), opts]],
   });
 }
 
 function withMethod(method) {
-  return transform("code", method, {});
+  return transform("code", { method }, () => {});
 }
 
 describe("method", () => {
@@ -21,5 +21,137 @@ describe("method", () => {
     expect(() => withMethod("foo")).toThrow(
       /entry-global.*usage-global.*usage-pure/,
     );
+  });
+});
+
+describe("shouldInjectPolyfill", () => {
+  it("is not compatible with .include", () => {
+    expect(() =>
+      transform(
+        "code",
+        {
+          method: "usage-global",
+          include: ["foo"],
+          shouldInjectPolyfill() {},
+        },
+        () => ({}),
+      ),
+    ).toThrow(/include.*shouldInjectPolyfill/);
+  });
+
+  it("is not compatible with .exclude", () => {
+    expect(() =>
+      transform(
+        "code",
+        {
+          method: "usage-global",
+          exclude: ["foo"],
+          shouldInjectPolyfill() {},
+        },
+        () => ({}),
+      ),
+    ).toThrow(/exclude.*shouldInjectPolyfill/);
+  });
+
+  it("should receive the correct default shouldInject (true)", () => {
+    let args;
+
+    transform(
+      "code",
+      {
+        method: "usage-global",
+        targets: { chrome: 50 },
+        shouldInjectPolyfill(...xs) {
+          args = xs;
+          return true;
+        },
+      },
+      ({ shouldInjectPolyfill }) => ({
+        polyfills: {
+          foo: { chrome: 60 },
+        },
+        usageGlobal() {
+          shouldInjectPolyfill("foo");
+        },
+      }),
+    );
+
+    expect(args).toEqual(["foo", true]);
+  });
+
+  it("should receive the correct default shouldInject (false)", () => {
+    let args;
+
+    transform(
+      "code",
+      {
+        method: "usage-global",
+        targets: { chrome: 50 },
+        shouldInjectPolyfill(...xs) {
+          args = xs;
+          return true;
+        },
+      },
+      ({ shouldInjectPolyfill }) => ({
+        polyfills: {
+          foo: { chrome: 40 },
+        },
+        usageGlobal() {
+          shouldInjectPolyfill("foo");
+        },
+      }),
+    );
+
+    expect(args).toEqual(["foo", false]);
+  });
+
+  it("can override the default shouldInject (true -> false)", () => {
+    let result;
+
+    transform(
+      "code",
+      {
+        method: "usage-global",
+        targets: { chrome: 50 },
+        shouldInjectPolyfill() {
+          return false;
+        },
+      },
+      ({ shouldInjectPolyfill }) => ({
+        polyfills: {
+          foo: { chrome: 60 },
+        },
+        usageGlobal() {
+          result = shouldInjectPolyfill("foo");
+        },
+      }),
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("can override the default shouldInject (false -> true)", () => {
+    let result;
+
+    transform(
+      "code",
+      {
+        method: "usage-global",
+        targets: { chrome: 50 },
+        shouldInjectPolyfill() {
+          return true;
+        },
+      },
+      ({ shouldInjectPolyfill }) => ({
+        polyfills: {
+          foo: { chrome: 40 },
+        },
+        usageGlobal() {
+          result = shouldInjectPolyfill("foo");
+        },
+      }),
+    );
+
+    expect(result).toBe(true);
   });
 });


### PR DESCRIPTION
This new API has the same goal as the include/exclude options
(for this reason, it will throw an error if you try to use both), but
both have some advantages that the other one doesn't have:
1) include/exclude are an array, so you can use them
    in a static JSON file. Also, they might be easier to use.
2) shouldInjectPolyfill is a function, so it is more powerful: for
    example, you could use it to store somewhere a list of all
    the injected polyfill, or to throw an error if a specific
    polyfill would be injected (maybe because it's too big and
    you want to be sure that you don't rely on it)

Fixes https://github.com/babel/babel-polyfills/issues/10, fixes https://github.com/babel/babel/issues/11583 (cc @niftylettuce), fixes https://github.com/babel/babel/issues/6625,  can fix https://github.com/babel/babel/issues/8489