### PR TITLE
fix: Promise.allSettled not included when it should be

### DIFF
--- a/packages/babel-plugin-polyfill-corejs3/src/built-in-definitions.js
+++ b/packages/babel-plugin-polyfill-corejs3/src/built-in-definitions.js
@@ -320,7 +320,7 @@ export const StaticProperties: ObjectMap<
   Promise: {
     all: define(null, PromiseDependenciesWithIterators),
     allSettled: define(null, [
-      "esnext.promise.all-settled",
+      "es.promise.all-settled",
       ...PromiseDependenciesWithIterators,
     ]),
     any: define(null, [


### PR DESCRIPTION
The other way to fix this would be to include it in shipped proposals. Effectively this is getting filtered out unless `proposals: true` is set when it shouldn't be since it's shipped and stage 4