### PR TITLE
Allow targets to be a string/array

### DIFF
--- a/packages/babel-helper-define-polyfill-provider/src/index.js
+++ b/packages/babel-helper-define-polyfill-provider/src/index.js
@@ -83,7 +83,12 @@ function resolveOptions<Options>(
     );
   }
 
-  const targets: Targets = getTargets(targetsOption, {
+  const targetsObj =
+    typeof targetsOption === "string" || Array.isArray(targetsOption)
+      ? { browsers: targetsOption }
+      : targetsOption;
+
+  const targets: Targets = getTargets(targetsObj, {
     ignoreBrowserslistConfig,
     configPath,
   });

--- a/packages/babel-helper-define-polyfill-provider/test/options.js
+++ b/packages/babel-helper-define-polyfill-provider/test/options.js
@@ -24,6 +24,37 @@ describe("method", () => {
   });
 });
 
+function extractTargets(targets) {
+  let resolved;
+  transform("code", { method: "usage-global", targets }, ({ targets }) => {
+    resolved = targets;
+    return {
+      usageGlobal() {},
+    };
+  });
+  return resolved;
+}
+
+describe("targets", () => {
+  it("accepts a string", () => {
+    const targets = extractTargets("firefox 67, ie 11");
+
+    expect(targets).toEqual({ firefox: "67.0.0", ie: "11.0.0" });
+  });
+
+  it("accepts an array", () => {
+    const targets = extractTargets(["firefox 67", "ie 11"]);
+
+    expect(targets).toEqual({ firefox: "67.0.0", ie: "11.0.0" });
+  });
+
+  it("accepts an object", () => {
+    const targets = extractTargets({ firefox: "67", ie: "11" });
+
+    expect(targets).toEqual({ firefox: "67.0.0", ie: "11.0.0" });
+  });
+});
+
 describe("shouldInjectPolyfill", () => {
   it("is not compatible with .include", () => {
     expect(() =>


### PR DESCRIPTION
Fixes #35 

preset-env code: https://github.com/babel/babel/blob/44f8287d7ac3c523a9425a7bb4beb4882090ae20/packages/babel-preset-env/src/normalize-options.js#L121-L127 (I'm not sure about what that comment means)
