### PR TITLE
Add .js extension to regenerator import

### DIFF
--- a/packages/babel-plugin-polyfill-regenerator/src/index.js
+++ b/packages/babel-plugin-polyfill-regenerator/src/index.js
@@ -11,7 +11,7 @@ export default defineProvider(({ debug }) => {
     usageGlobal(meta, utils) {
       if (isRegenerator(meta)) {
         debug("regenerator-runtime");
-        utils.injectGlobalImport("regenerator-runtime/runtime");
+        utils.injectGlobalImport("regenerator-runtime/runtime.js");
       }
     },
     usagePure(meta, utils, path) {

--- a/packages/babel-plugin-polyfill-regenerator/test/fixtures/usage-global/all/output.mjs
+++ b/packages/babel-plugin-polyfill-regenerator/test/fixtures/usage-global/all/output.mjs
@@ -1,2 +1,2 @@
-import "regenerator-runtime/runtime";
+import "regenerator-runtime/runtime.js";
 regeneratorRuntime.wrap(function () {});

--- a/packages/babel-plugin-polyfill-regenerator/test/fixtures/usage-global/async/output.mjs
+++ b/packages/babel-plugin-polyfill-regenerator/test/fixtures/usage-global/async/output.mjs
@@ -1,4 +1,4 @@
-import "regenerator-runtime/runtime";
+import "regenerator-runtime/runtime.js";
 import "core-js/modules/es6.object.to-string.js";
 import "core-js/modules/es6.promise.js";
 

--- a/packages/babel-plugin-polyfill-regenerator/test/fixtures/usage-global/generator/output.mjs
+++ b/packages/babel-plugin-polyfill-regenerator/test/fixtures/usage-global/generator/output.mjs
@@ -1,4 +1,4 @@
-import "regenerator-runtime/runtime";
+import "regenerator-runtime/runtime.js";
 
 var _marked = /*#__PURE__*/regeneratorRuntime.mark(a);
 


### PR DESCRIPTION
https://github.com/babel/babel/commit/1382437ad61aeeae9fba87c880517a7167df5a14. These packages already added the extension for core-js, but not for regenerator.