### PR TITLE
Use the top-level `targets` option

### DIFF
--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/top-level-targets/simple/input.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/top-level-targets/simple/input.mjs
@@ -1,0 +1,2 @@
+Promise.prototype.finally;
+Array.from

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/top-level-targets/simple/options.json
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/top-level-targets/simple/options.json
@@ -1,0 +1,6 @@
+{
+	"targets": "chrome 60",
+	"plugins": [
+	  ["@@/polyfill-corejs3", { "method": "usage-global" }]
+	]
+  }

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/top-level-targets/simple/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/top-level-targets/simple/output.mjs
@@ -1,0 +1,4 @@
+import "core-js/modules/es.promise.finally.js";
+import "core-js/modules/es.promise.js";
+Promise.prototype.finally;
+Array.from;


### PR DESCRIPTION
This feature is for the helper package (not only for corejs3), but I added a test in corejs3 to show the behavior.