### PR TITLE
fix: avoid injecting uknown polyfill

### DIFF
--- a/packages/babel-plugin-polyfill-corejs2/test/fixtures/usage-global/unknown-polyfill/input.mjs
+++ b/packages/babel-plugin-polyfill-corejs2/test/fixtures/usage-global/unknown-polyfill/input.mjs
@@ -1,0 +1,1 @@
+var a = Array.from(1,2,3)

--- a/packages/babel-plugin-polyfill-corejs2/test/fixtures/usage-global/unknown-polyfill/options.json
+++ b/packages/babel-plugin-polyfill-corejs2/test/fixtures/usage-global/unknown-polyfill/options.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    [
+      "@@/polyfill-corejs2",
+      {
+        "targets": { "node": "0.12" },
+        "method": "usage-global"
+      }
+    ]
+  ]
+}

--- a/packages/babel-plugin-polyfill-corejs2/test/fixtures/usage-global/unknown-polyfill/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs2/test/fixtures/usage-global/unknown-polyfill/output.mjs
@@ -1,0 +1,5 @@
+import "core-js/modules/es6.symbol.js";
+import "core-js/modules/es6.array.from.js";
+import "core-js/modules/es6.object.to-string.js";
+import "core-js/modules/es6.array.iterator.js";
+var a = Array.from(1, 2, 3);


### PR DESCRIPTION
Fix `Internal error in the corejs2 provider: unknown polyfill "web.dom.iterable"`

Related discussion https://github.com/babel/babel/pull/12870#issuecomment-784574841