### PR TITLE
Remove 1 second delay on process exit

### DIFF
--- a/packages/babel-helper-define-polyfill-provider/src/node/dependencies.js
+++ b/packages/babel-helper-define-polyfill-provider/src/node/dependencies.js
@@ -95,9 +95,11 @@ let allMissingDeps = new Set();
 const laterLogMissingDependencies = debounce(() => {
   logMissing(allMissingDeps);
   allMissingDeps = new Set();
-}, 1000);
+}, 100);
 
 export function laterLogMissing(missingDeps: Set<string>) {
+  if (missingDeps.size === 0) return;
+
   missingDeps.forEach(name => allMissingDeps.add(name));
   laterLogMissingDependencies();
 }


### PR DESCRIPTION
Reduce the delay to 100 ms, and don’t delay at all if there’s nothing to log.

Fixes #63.