### PR TITLE
Fix typo in documentation (absoluteRuntime -> absoluteImports)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -74,7 +74,7 @@ The `shouldInjectPolyfill` function takes two parameters: the name of the polyfi
 function shouldInjectPolyfill(name: string, defaultShouldInject: boolean): boolean;
 ```
 
-### `absoluteRuntime`
+### `absoluteImports`
 
 `boolean` or `string`, defaults to `false`.
 


### PR DESCRIPTION
It's awesome that this works (once I used the correct name.)