### PR TITLE
[corejs3] Inject `usage-global` imports in the correct order

### DIFF
--- a/packages/babel-plugin-polyfill-corejs3/src/built-in-definitions.js
+++ b/packages/babel-plugin-polyfill-corejs3/src/built-in-definitions.js
@@ -1,5 +1,7 @@
 // @flow
 
+import corejs3Polyfills from "../core-js-compat/data.js";
+
 type ObjectMap<V> = { [name: string]: V };
 
 export type CoreJSPolyfillDescriptor = {
@@ -9,13 +11,23 @@ export type CoreJSPolyfillDescriptor = {
   exclude: ?(string[]),
 };
 
+const polyfillsOrder = {};
+Object.keys(corejs3Polyfills).forEach((name, index) => {
+  polyfillsOrder[name] = index;
+});
+
 const define = (
   pure,
   global,
   name = global[0],
   exclude,
 ): CoreJSPolyfillDescriptor => {
-  return { name, pure, global, exclude };
+  return {
+    name,
+    pure,
+    global: global.sort((a, b) => polyfillsOrder[a] - polyfillsOrder[b]),
+    exclude,
+  };
 };
 
 const typed = (name: string) => define(null, [name, ...TypedArrayDependencies]);

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/top-level-targets/simple/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/top-level-targets/simple/output.mjs
@@ -1,4 +1,4 @@
-import "core-js/modules/es.promise.finally.js";
 import "core-js/modules/es.promise.js";
+import "core-js/modules/es.promise.finally.js";
 Promise.prototype.finally;
 Array.from;

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/all-proposals/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/all-proposals/output.mjs
@@ -1,6 +1,8 @@
 import "core-js/modules/es.array.from.js";
 import "core-js/modules/es.string.iterator.js";
+import "core-js/modules/es.array.iterator.js";
 import "core-js/modules/es.map.js";
+import "core-js/modules/es.object.to-string.js";
 import "core-js/modules/esnext.map.delete-all.js";
 import "core-js/modules/esnext.map.every.js";
 import "core-js/modules/esnext.map.filter.js";
@@ -14,8 +16,6 @@ import "core-js/modules/esnext.map.merge.js";
 import "core-js/modules/esnext.map.reduce.js";
 import "core-js/modules/esnext.map.some.js";
 import "core-js/modules/esnext.map.update.js";
-import "core-js/modules/es.object.to-string.js";
-import "core-js/modules/es.array.iterator.js";
 import "core-js/modules/web.dom-collections.iterator.js";
 import "core-js/modules/es.promise.js";
 import "core-js/modules/es.symbol.match.js";

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/all/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/all/output.mjs
@@ -1,8 +1,8 @@
 import "core-js/modules/es.array.from.js";
 import "core-js/modules/es.string.iterator.js";
+import "core-js/modules/es.array.iterator.js";
 import "core-js/modules/es.map.js";
 import "core-js/modules/es.object.to-string.js";
-import "core-js/modules/es.array.iterator.js";
 import "core-js/modules/web.dom-collections.iterator.js";
 import "core-js/modules/es.promise.js";
 import "core-js/modules/es.symbol.match.js";

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/built-in-from-global-object/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/built-in-from-global-object/output.mjs
@@ -1,7 +1,7 @@
-import "core-js/modules/es.set.js";
-import "core-js/modules/es.object.to-string.js";
-import "core-js/modules/es.string.iterator.js";
 import "core-js/modules/es.array.iterator.js";
+import "core-js/modules/es.object.to-string.js";
+import "core-js/modules/es.set.js";
+import "core-js/modules/es.string.iterator.js";
 import "core-js/modules/web.dom-collections.iterator.js";
 const Set = window.Set;
 const Map = something.Map;

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/determanated-instance-methods/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/determanated-instance-methods/output.mjs
@@ -1,7 +1,7 @@
-import "core-js/modules/es.object.to-string.js";
 import "core-js/modules/es.array.iterator.js";
-import "core-js/modules/es.string.replace.js";
+import "core-js/modules/es.object.to-string.js";
 import "core-js/modules/es.regexp.exec.js";
+import "core-js/modules/es.string.replace.js";
 import "core-js/modules/es.string.includes.js";
 import "core-js/modules/es.regexp.flags.js";
 import "core-js/modules/es.object.define-getter.js";

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/dynamic-import-webpack/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/dynamic-import-webpack/output.mjs
@@ -1,7 +1,7 @@
-import "core-js/modules/es.promise.js";
-import "core-js/modules/es.object.to-string.js";
-import "core-js/modules/es.string.iterator.js";
 import "core-js/modules/es.array.iterator.js";
+import "core-js/modules/es.object.to-string.js";
+import "core-js/modules/es.promise.js";
+import "core-js/modules/es.string.iterator.js";
 import "core-js/modules/web.dom-collections.iterator.js";
 // https://github.com/babel/babel/issues/9872
 import("foo");

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/dynamic-import/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/dynamic-import/output.mjs
@@ -1,3 +1,3 @@
-import "core-js/modules/es.promise.js";
 import "core-js/modules/es.object.to-string.js";
+import "core-js/modules/es.promise.js";
 const foo = import('foo');

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/evaluated-class-methods/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/evaluated-class-methods/output.mjs
@@ -1,5 +1,5 @@
-import "core-js/modules/es.object.to-string.js";
 import "core-js/modules/es.array.iterator.js";
+import "core-js/modules/es.object.to-string.js";
 import "core-js/modules/web.dom-collections.iterator.js";
 import "core-js/modules/es.object.assign.js";
 var objectClass = Object;

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/fetch/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/fetch/output.mjs
@@ -1,3 +1,3 @@
-import "core-js/modules/es.promise.js";
 import "core-js/modules/es.object.to-string.js";
+import "core-js/modules/es.promise.js";
 const foo = fetch('foo');

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/in/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/in/output.mjs
@@ -1,8 +1,8 @@
 import "core-js/modules/es.object.entries.js";
 import "core-js/modules/es.array.includes.js";
 import "core-js/modules/es.object.values.js";
-import "core-js/modules/es.object.from-entries.js";
 import "core-js/modules/es.array.iterator.js";
+import "core-js/modules/es.object.from-entries.js";
 'entries' in Object;
 'includes' in [1, 2, 3];
 'va' + 'lues' in Object;

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/instance-methods/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/instance-methods/output.mjs
@@ -1,8 +1,8 @@
 import "core-js/modules/es.array.from.js";
 import "core-js/modules/es.string.iterator.js";
+import "core-js/modules/es.array.iterator.js";
 import "core-js/modules/es.map.js";
 import "core-js/modules/es.object.to-string.js";
-import "core-js/modules/es.array.iterator.js";
 import "core-js/modules/web.dom-collections.iterator.js";
 import "core-js/modules/es.array.includes.js";
 import "core-js/modules/es.string.includes.js";
@@ -16,8 +16,8 @@ import "core-js/modules/es.string.code-point-at.js";
 import "core-js/modules/es.string.ends-with.js";
 import "core-js/modules/es.array.reverse.js";
 import "core-js/modules/es.array.copy-within.js";
-import "core-js/modules/es.string.search.js";
 import "core-js/modules/es.regexp.exec.js";
+import "core-js/modules/es.string.search.js";
 import "core-js/modules/es.string.replace.js";
 import "core-js/modules/es.string.split.js";
 Array.from; // static function

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/modules-transform/output.js
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/modules-transform/output.js
@@ -1,7 +1,7 @@
 "use strict";
 
-require("core-js/modules/es.promise.js");
-
 require("core-js/modules/es.object.to-string.js");
+
+require("core-js/modules/es.promise.js");
 
 Promise;

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/object-destructuring/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/object-destructuring/output.mjs
@@ -1,8 +1,8 @@
 import "core-js/modules/es.function.bind.js";
 import "core-js/modules/es.object.entries.js";
+import "core-js/modules/es.date.to-string.js";
 import "core-js/modules/es.object.to-string.js";
 import "core-js/modules/es.regexp.to-string.js";
-import "core-js/modules/es.date.to-string.js";
 import "core-js/modules/es.string.iterator.js";
 import "core-js/modules/es.array.iterator.js";
 import "core-js/modules/web.dom-collections.iterator.js";

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/promise-all/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/promise-all/output.mjs
@@ -1,7 +1,7 @@
-import "core-js/modules/es.promise.js";
 import "core-js/modules/es.object.to-string.js";
-import "core-js/modules/es.string.iterator.js";
+import "core-js/modules/es.promise.js";
 import "core-js/modules/es.array.iterator.js";
+import "core-js/modules/es.string.iterator.js";
 import "core-js/modules/web.dom-collections.iterator.js";
 var p = Promise.resolve(0);
 Promise.all([p]).then(outcome => {

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/promise-finally/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/promise-finally/output.mjs
@@ -1,5 +1,5 @@
-import "core-js/modules/es.promise.js";
 import "core-js/modules/es.object.to-string.js";
+import "core-js/modules/es.promise.js";
 import "core-js/modules/es.promise.finally.js";
 var p = Promise.resolve(0);
 p.finally(() => {

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/promise-race/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/promise-race/output.mjs
@@ -1,7 +1,7 @@
-import "core-js/modules/es.promise.js";
 import "core-js/modules/es.object.to-string.js";
-import "core-js/modules/es.string.iterator.js";
+import "core-js/modules/es.promise.js";
 import "core-js/modules/es.array.iterator.js";
+import "core-js/modules/es.string.iterator.js";
 import "core-js/modules/web.dom-collections.iterator.js";
 var p = Promise.resolve(0);
 Promise.race([p]).then(outcome => {

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/shippedProposals/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/shippedProposals/output.mjs
@@ -1,8 +1,8 @@
 import "core-js/modules/es.array.from.js";
 import "core-js/modules/es.string.iterator.js";
+import "core-js/modules/es.array.iterator.js";
 import "core-js/modules/es.map.js";
 import "core-js/modules/es.object.to-string.js";
-import "core-js/modules/es.array.iterator.js";
 import "core-js/modules/web.dom-collections.iterator.js";
 import "core-js/modules/es.promise.js";
 import "core-js/modules/es.symbol.match.js";

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/source-type-script-query/output.js
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/source-type-script-query/output.js
@@ -1,6 +1,6 @@
-require("core-js/modules/es.promise.js");
-
 require("core-js/modules/es.object.to-string.js");
+
+require("core-js/modules/es.promise.js");
 
 require("core-js/modules/es.array.includes.js");
 

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/source-type-script/output.js
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/source-type-script/output.js
@@ -1,6 +1,6 @@
-require("core-js/modules/es.promise.js");
-
 require("core-js/modules/es.object.to-string.js");
+
+require("core-js/modules/es.promise.js");
 
 require("core-js/modules/es.array.includes.js");
 

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/symbol-iterator-in/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/symbol-iterator-in/output.mjs
@@ -1,7 +1,7 @@
 import "core-js/modules/es.symbol.iterator.js";
+import "core-js/modules/es.array.iterator.js";
 import "core-js/modules/es.object.to-string.js";
 import "core-js/modules/es.string.iterator.js";
-import "core-js/modules/es.array.iterator.js";
 import "core-js/modules/web.dom-collections.iterator.js";
 import "core-js/modules/es.symbol.js";
 import "core-js/modules/es.symbol.description.js";

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/symbol-iterator/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/symbol-iterator/output.mjs
@@ -1,7 +1,7 @@
 import "core-js/modules/es.symbol.iterator.js";
+import "core-js/modules/es.array.iterator.js";
 import "core-js/modules/es.object.to-string.js";
 import "core-js/modules/es.string.iterator.js";
-import "core-js/modules/es.array.iterator.js";
 import "core-js/modules/web.dom-collections.iterator.js";
 import "core-js/modules/es.symbol.js";
 import "core-js/modules/es.symbol.description.js";

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/timers/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/timers/output.mjs
@@ -1,5 +1,5 @@
-import "core-js/modules/es.promise.js";
 import "core-js/modules/es.object.to-string.js";
+import "core-js/modules/es.promise.js";
 import "core-js/modules/web.timers.js";
 import "core-js/modules/web.immediate.js";
 Promise.resolve().then(it => {

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/typed-array-edge-13/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/typed-array-edge-13/output.mjs
@@ -1,6 +1,6 @@
+import "core-js/modules/es.array.iterator.js";
+import "core-js/modules/es.object.to-string.js";
 import "core-js/modules/es.typed-array.int8-array.js";
 import "core-js/modules/es.typed-array.includes.js";
 import "core-js/modules/es.typed-array.to-locale-string.js";
-import "core-js/modules/es.object.to-string.js";
-import "core-js/modules/es.array.iterator.js";
 new Int8Array(1);

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/typed-array-static/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/typed-array-static/output.mjs
@@ -1,4 +1,7 @@
 import "core-js/modules/es.typed-array.of.js";
+import "core-js/modules/es.array.iterator.js";
+import "core-js/modules/es.array-buffer.slice.js";
+import "core-js/modules/es.object.to-string.js";
 import "core-js/modules/es.typed-array.int8-array.js";
 import "core-js/modules/es.typed-array.copy-within.js";
 import "core-js/modules/es.typed-array.every.js";
@@ -23,7 +26,4 @@ import "core-js/modules/es.typed-array.sort.js";
 import "core-js/modules/es.typed-array.subarray.js";
 import "core-js/modules/es.typed-array.to-locale-string.js";
 import "core-js/modules/es.typed-array.to-string.js";
-import "core-js/modules/es.object.to-string.js";
-import "core-js/modules/es.array.iterator.js";
-import "core-js/modules/es.array-buffer.slice.js";
 Int8Array.of();

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/typed-array/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-global/typed-array/output.mjs
@@ -1,3 +1,6 @@
+import "core-js/modules/es.array.iterator.js";
+import "core-js/modules/es.array-buffer.slice.js";
+import "core-js/modules/es.object.to-string.js";
 import "core-js/modules/es.typed-array.int8-array.js";
 import "core-js/modules/es.typed-array.copy-within.js";
 import "core-js/modules/es.typed-array.every.js";
@@ -22,7 +25,4 @@ import "core-js/modules/es.typed-array.sort.js";
 import "core-js/modules/es.typed-array.subarray.js";
 import "core-js/modules/es.typed-array.to-locale-string.js";
 import "core-js/modules/es.typed-array.to-string.js";
-import "core-js/modules/es.object.to-string.js";
-import "core-js/modules/es.array.iterator.js";
-import "core-js/modules/es.array-buffer.slice.js";
 new Int8Array(1);


### PR DESCRIPTION
This PR ensures that we inject dependencies _before_ the polyfill that depends on them. You can use [this 7.12.0 repl](https://babeljs.io/repl/version/7.12.0) to test the old behavior.

Fixes https://github.com/babel/babel-polyfills/issues/77.