### PR TITLE
Fix compatibility with native ESM interop

### DIFF
--- a/packages/babel-helper-define-polyfill-provider/src/index.js
+++ b/packages/babel-helper-define-polyfill-provider/src/index.js
@@ -3,10 +3,11 @@
 import { declare } from "@babel/helper-plugin-utils";
 import type { NodePath } from "@babel/traverse";
 
-import getTargets, {
+import _getTargets, {
   isRequired,
   getInclusionReasons,
 } from "@babel/helper-compilation-targets";
+const getTargets = _getTargets.default || _getTargets;
 
 import { createUtilsGetter } from "./utils";
 import ImportsCache from "./imports-cache";


### PR DESCRIPTION
I found this while updating these packages in Babel.

In Node.js `getTargets` is the `.default` property of the `default` import, while in bundlers (or in compiled code) it's the `default` export itself.