### PR TITLE
Add `dirname` to the cache key for missing dependencies

### DIFF
--- a/packages/babel-helper-define-polyfill-provider/src/index.js
+++ b/packages/babel-helper-define-polyfill-provider/src/index.js
@@ -224,7 +224,11 @@ function instantiateProvider<Options>(
 
       const found = missingDependencies.all
         ? false
-        : mapGetOr(depsCache, name, () => !deps.has(dirname, name));
+        : mapGetOr(
+            depsCache,
+            `${name} :: ${dirname}`,
+            () => !deps.has(dirname, name),
+          );
 
       if (!found) {
         debugLog().missingDeps.add(dep);


### PR DESCRIPTION
I noticed this because of the log in https://github.com/babel/babel/runs/2671118012: it logs but the polyfill is correctly installed.