### PR TITLE
docs: remove leftover references to duplicate targets

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -2,8 +2,6 @@
 
 All the existig capabilities of `@babel/preset-env` and `@babel/plugin-transform-runtime` related to `core-js` are supported by the polyfill providers implemented in this repository.
 
-> You'll notice that you currently have to duplicate your `targets` (unles you are using a `.browserslistrc` file). We are working on deduplicating the option: [`babel/rfcs#2`](https://github.com/babel/rfcs/pull/2).
-
 ### `core-js@3`
 
 <!-- prettier-ignore-start -->
@@ -117,7 +115,7 @@ All the existig capabilities of `@babel/preset-env` and `@babel/plugin-transform
 </td>
 <td>
 
-```json5
+```json
 {
   "presets": [
     ["@babel/preset-env", {
@@ -145,7 +143,7 @@ All the existig capabilities of `@babel/preset-env` and `@babel/plugin-transform
 <!-- prettier-ignore-start -->
 <table>
 <thead><tr>
-<th align="center">Old configuration (with `core-js`)</th>
+<th align="center">Old configuration (with <code>core-js</code>)</th>
 <th align="center">New configuration</th>
 </tr></thead>
 <tr>
@@ -186,7 +184,7 @@ All the existig capabilities of `@babel/preset-env` and `@babel/plugin-transform
 <!-- prettier-ignore-start -->
 <table>
 <thead><tr>
-<th align="center">Old configuration (with `core-js`)</th>
+<th align="center">Old configuration (with <code>core-js</code>)</th>
 <th align="center">New configuration</th>
 </tr></thead>
 <tr>
@@ -210,7 +208,7 @@ All the existig capabilities of `@babel/preset-env` and `@babel/plugin-transform
 </td>
 <td>
 
-```json5
+```json
 {
   "presets": [
     ["@babel/preset-env", {
@@ -345,7 +343,7 @@ All the existig capabilities of `@babel/preset-env` and `@babel/plugin-transform
 </td>
 <td>
 
-```jsonc
+```json
 {
   "presets": [
     ["@babel/preset-env", {


### PR DESCRIPTION
## Summary

Follow-up to 1091fa4e27a597148403545d21e776dadeb5c518

## Details

- 1091fa4e27a597148403545d21e776dadeb5c518 switched the examples to use
  top-level targets, but this note at the top was leftover

- in the same commit, the comments within JSON were removed, so the
  syntax highlighting can be set back to regular JSON instead of
  JSON5 or JSONC
  - Notably, GitHub was not correctly rendering anything other than JSON

- also fix syntax highlighting within an HTML table by using
  HTML `<code>` blocks instead of Markdown backticks
  
### Screenshot

Here's what the improperly highlighted sections looked like on GitHub (both the JSON5 and the backticks):
![Screen Shot 2022-03-01 at 6 44 10 PM](https://user-images.githubusercontent.com/4970083/156269173-24f79a52-6e96-4cf6-9049-5cc597026a5f.png)

Can see the before/after below:
[Old Markdown Preview](https://github.com/babel/babel-polyfills/blob/1091fa4e27a597148403545d21e776dadeb5c518/docs/migration.md#es-shims) vs. [New Markdown Preview](https://github.com/babel/babel-polyfills/blob/1ec29ee32752e9b382235d979d1d71fd3b0bbbb9/docs/migration.md#es-shims)

## References

Closes #18  
It's been open for a while and this removes the last reference to the top-level targets RFC, so it is now a quite outdated issue