### PR TITLE
docs: add a simple CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+Start with the [Babel core Contributing docs](https://github.com/babel/babel/blob/main/CONTRIBUTING.md).
+
+## Developing
+
+### Setup
+
+Fork the `babel-polyfills` repository to your GitHub Account.
+
+Then, run:
+
+```sh
+$ git clone https://github.com/<your-github-username>/babel-polyfills
+$ cd babel-polyfills
+$ yarn
+```
+
+Then you can either run:
+
+```sh
+$ yarn build
+```
+
+to build the repo **once** or:
+
+```sh
+$ yarn watch
+```
+
+to have the repo build itself and incrementally build files on change.
+
+### Running linting/type-checking/tests
+
+#### Lint
+
+```sh
+$ yarn lint
+```
+
+#### Type-check
+
+```sh
+$ yarn flow
+```
+
+#### Test
+
+```sh
+$ yarn test
+```
+
+## Creating a new polyfill
+
+See [`docs/polyfill-provider.md`](https://github.com/babel/babel-polyfills/blob/main/docs/polyfill-provider.md).

--- a/README.md
+++ b/README.md
@@ -235,3 +235,7 @@ Our old approach has two main problems:
 - We forced our users to use `core-js` if they wanted a Babel integration. `core-js` is a good and comprehensive polyfill, but it doesn't fit the needs of all of our users.
 
 With this new packages we are proposing a solution for both of these problem, while still maintaining full backward compatibility.
+
+### Want to contribute?
+
+See our [CONTRIBUTING.md](CONTRIBUTING.md) to get started with setting up the repo.

--- a/docs/polyfill-provider.md
+++ b/docs/polyfill-provider.md
@@ -3,7 +3,7 @@ Their job is to provide the correct import paths for every functionality that th
 
 > You can find some examples in the [`packages`](https://github.com/nicolo-ribaudo/babel-polyfills/tree/main/packages) folder of this repository
 
-A _"polyfill provider"_ is defined passing a factory function to `@babel/helper-define-polyfill-provider`. The factory functiontakes two parameters (`api` and `options`) and returns an object with the provider implementation.
+A _"polyfill provider"_ is defined passing a factory function to `@babel/helper-define-polyfill-provider`. The factory function takes two parameters (`api` and `options`) and returns an object with the provider implementation.
 
 ```ts
 function polyfillProvider(api: ProviderApi, options: Options): Provider;


### PR DESCRIPTION
## Summary

adds a simple `CONTRIBUTING.md` based on / similar to [Babel core's `CONTRIBUTING.md`](https://github.com/babel/babel/blob/main/CONTRIBUTING.md)

## Details

- none existed, so I had to figure out how to set-up the repo myself
  when trying to contribute code and tests

- references [Babel core's `CONTRIBUTING.md`](https://github.com/babel/babel/blob/main/CONTRIBUTING.md) and [`docs/polyfill-provider.md`](https://github.com/babel/babel-polyfills/blob/main/docs/polyfill-provider.md)
  - also fix a tiny typo in `polyfill-provider.md`
  
- add a "Want to contribute?" section to `README` similar to
  [Babel core's `README`](https://github.com/babel/babel#want-to-contribute-to-babel)
  
## References

I was working on PRs for #17 and #36 (respectively, #118 and #119 ) and the first step for that was figuring out how to set-up the repo!
  
  