### PR TITLE
feat: better error message when no options are provided

### DIFF
--- a/packages/babel-helper-define-polyfill-provider/src/index.js
+++ b/packages/babel-helper-define-polyfill-provider/src/index.js
@@ -60,6 +60,20 @@ function resolveOptions<Options>(
     ...providerOptions
   } = options;
 
+  if (isEmpty(options)) {
+    throw new Error(
+      `\
+This plugin requires options, for example:
+    {
+      "plugins": [
+        ["<plugin name>", { method: "usage-pure" }]
+      ]
+    }
+
+See more options at https://github.com/babel/babel-polyfills/blob/main/docs/usage.md`,
+    );
+  }
+
   let methodName;
   if (method === "usage-global") methodName = "usageGlobal";
   else if (method === "entry-global") methodName = "entryGlobal";
@@ -395,4 +409,8 @@ function mapGetOr(map, key, getDefault) {
     map.set(key, val);
   }
   return val;
+}
+
+function isEmpty(obj) {
+  return Object.keys(obj).length === 0;
 }

--- a/packages/babel-helper-define-polyfill-provider/test/options.js
+++ b/packages/babel-helper-define-polyfill-provider/test/options.js
@@ -8,6 +8,12 @@ function transform(code, opts, provider) {
   });
 }
 
+describe("options", () => {
+  it("must be non-empty", () => {
+    expect(() => transform("code", {}, () => {})).toThrow(/requires/);
+  });
+});
+
 function withMethod(method) {
   return transform("code", { method }, () => {});
 }


### PR DESCRIPTION
## Summary

adds a detailed error message when no options are provided to a polyfill plugin as requested in #17

## Details

- previously, if polyfills were ran without options, it would just
  throw ".method must be a string", which is not very intuitive
  - now, say that the plugin requires options, give an example of a
    config with options, and link to the docs for further reference

- add a test for this new error as well

## Review Notes

I haven't used Flow before (only TS), so let me know if I should have done some flow typing anywhere.
(for context: I was thinking I could put a type-guard or something around `isEmpty`, but given that that's a more advanced TS feature, I was not really sure how to do so in Flow)

## References

Fixes #17