### PR TITLE
[es-shims] Add change-array-by-copy proposal methods

### DIFF
--- a/packages/babel-plugin-polyfill-corejs3/src/built-in-definitions.ts
+++ b/packages/babel-plugin-polyfill-corejs3/src/built-in-definitions.ts
@@ -805,7 +805,7 @@ export const InstanceProperties = {
     "esnext.array.to-sorted",
     "es.array.sort",
   ]),
-  toSpliced: define("instance/to-reversed", ["esnext.array.to-spliced"]),
+  toSpliced: define("instance/to-spliced", ["esnext.array.to-spliced"]),
   toString: define(null, [
     "es.object.to-string",
     "es.error.to-string",

--- a/packages/babel-plugin-polyfill-es-shims/README.md
+++ b/packages/babel-plugin-polyfill-es-shims/README.md
@@ -36,6 +36,10 @@ This polyfill provider is compatible with polyfills that follow the [`es-shims-a
 | :------------------------------ | :------------------------------------------------------------------------------------------- | :---- |
 | `Array.prototype.findLast`      | [`array.prototype.findlast`](https://github.com/es-shims/Array.prototype.findLast)           |
 | `Array.prototype.findLastIndex` | [`array.prototype.findlastindex`](https://github.com/es-shims/Array.prototype.findLastIndex) |
+| `Array.prototype.toReversed`    | [`array.prototype.toreversed`](https://github.com/es-shims/Array.prototype.toReversed)       |
+| `Array.prototype.toSorted`      | [`array.prototype.tosorted`](https://github.com/es-shims/Array.prototype.toSorted)           |
+| `Array.prototype.toSpliced`     | [`array.prototype.tospliced`](https://github.com/es-shims/Array.prototype.toSpliced)         |
+| `Array.prototype.with`          | [`array.prototype.with`](https://github.com/es-shims/Array.prototype.with)                   |
 
 ### ES2022
 

--- a/packages/babel-plugin-polyfill-es-shims/README.md
+++ b/packages/babel-plugin-polyfill-es-shims/README.md
@@ -30,14 +30,21 @@ This package supports the `usage-pure` and `usage-global` methods.
 
 This polyfill provider is compatible with polyfills that follow the [`es-shims-api`](https://github.com/es-shims/es-shim-api) specification. Those polyfills must live under the [`@es-shims`](https://github.com/es-shims) organization, but for historical reasons some of them are owned by different people: they are explicitly marked as such in the following tables.
 
+### Proposals (Stage 3)
+
+| Builtin object or function      | Package name                                                                                 | Owner |
+| :------------------------------ | :------------------------------------------------------------------------------------------- | :---- |
+| `Array.prototype.findLast`      | [`array.prototype.findlast`](https://github.com/es-shims/Array.prototype.findLast)           |
+| `Array.prototype.findLastIndex` | [`array.prototype.findlastindex`](https://github.com/es-shims/Array.prototype.findLastIndex) |
+
 ### ES2022
 
-| Builtin object or function | Package name                                                                 | Owner |
-| :------------------------- | :--------------------------------------------------------------------------- | :---- |
-| `Array.prototype.at`     | [`array.prototype.at`](https://github.com/es-shims/Array.prototype.at)   |
-| `Error`'s `cause` property | [`error-cause`](https://github.com/es-shims/error-cause)               |
-| `Object.hasOwn`          | [`object.hasown`](https://github.com/es-shims/object.hasown)             |
-| `String.prototype.at`    | [`string.prototype.at`](https://github.com/es-shims/String.prototype.at) |
+| Builtin object or function | Package name                                                             | Owner |
+| :------------------------- | :----------------------------------------------------------------------- | :---- |
+| `Array.prototype.at`       | [`array.prototype.at`](https://github.com/es-shims/Array.prototype.at)   |
+| `Error`'s `cause` property | [`error-cause`](https://github.com/es-shims/error-cause)                 |
+| `Object.hasOwn`            | [`object.hasown`](https://github.com/es-shims/object.hasown)             |
+| `String.prototype.at`      | [`string.prototype.at`](https://github.com/es-shims/String.prototype.at) |
 
 ### ES2021
 
@@ -53,7 +60,7 @@ This polyfill provider is compatible with polyfills that follow the [`es-shims-a
 | :-------------------------- | :--------------------------------------------------------------------------------- | :---- |
 | `globalThis`                | [`globalthis`](https://github.com/es-shims/globalThis)                             |
 | `Promise.allSettled`        | [`promise.allsettled`](https://github.com/es-shims/Promise.allSettled)             |
-| `String.prototype.matchAll` | [`string.prototype.matchall`](https://github.com/ljharb/String.prototype.matchAll) |               |
+| `String.prototype.matchAll` | [`string.prototype.matchall`](https://github.com/ljharb/String.prototype.matchAll) |
 
 ### ES2019
 
@@ -146,4 +153,4 @@ This polyfill provider is compatible with polyfills that follow the [`es-shims-a
 | `Array.prototype.some`           | [`array.prototype.some`](https://github.com/es-shims/Array.prototype.some)                     |
 | `Number.prototype.toExponential` | [`number.prototype.toexponential`](https://github.com/es-shims/Number.prototype.toExponential) |
 | `String.prototype.split`         | [`string.prototype.split`](https://github.com/es-shims/String.prototype.split)                 |
-| `String.prototype.trim`          | [`string.prototype.trim`](https://github.com/es-shims/String.prototype.trim)    
+| `String.prototype.trim`          | [`string.prototype.trim`](https://github.com/es-shims/String.prototype.trim)                   |

--- a/packages/babel-plugin-polyfill-es-shims/data/polyfills.json
+++ b/packages/babel-plugin-polyfill-es-shims/data/polyfills.json
@@ -1014,5 +1014,9 @@
     "phantom": "2",
     "samsung": "1",
     "electron": "0.20"
-  }
+  },
+  "Array.prototype.toReversed": {},
+  "Array.prototype.toSorted": {},
+  "Array.prototype.toSpliced": {},
+  "Array.prototype.with": {}
 }

--- a/packages/babel-plugin-polyfill-es-shims/src/mappings.ts
+++ b/packages/babel-plugin-polyfill-es-shims/src/mappings.ts
@@ -88,7 +88,11 @@ defineInstance("Array", "map", "1.0.2", arrayCheck);
 defineInstance("Array", "reduce", "1.0.1", arrayCheck);
 defineInstance("Array", "reduceRight", "1.0.1", arrayCheck);
 defineInstance("Array", "some", "1.1.1", arrayCheck);
+defineInstance("Array", "toReversed", "1.0.1", arrayCheck);
+defineInstance("Array", "toSorted", "1.0.0", arrayCheck);
+defineInstance("Array", "toSpliced", "1.0.0", arrayCheck);
 defineInstance("Array", "values", "1.0.0", arrayCheck, excludeObject);
+defineInstance("Array", "with", "1.0.1", arrayCheck);
 
 defineInstance("Function", "name", "1.1.2", typeofCheck("function"), getter);
 

--- a/packages/babel-plugin-polyfill-es-shims/test/fixtures/usage-global/proposal-change-array-by-copy/input.mjs
+++ b/packages/babel-plugin-polyfill-es-shims/test/fixtures/usage-global/proposal-change-array-by-copy/input.mjs
@@ -1,0 +1,4 @@
+arr.with(0, 3);
+arr.toSorted();
+arr.toReversed();
+arr.toSpliced(1, 1, 3, 4);

--- a/packages/babel-plugin-polyfill-es-shims/test/fixtures/usage-global/proposal-change-array-by-copy/options.json
+++ b/packages/babel-plugin-polyfill-es-shims/test/fixtures/usage-global/proposal-change-array-by-copy/options.json
@@ -1,0 +1,15 @@
+{
+  "validateLogs": true,
+  "plugins": [
+    [
+      "@@/polyfill-es-shims",
+      {
+        "method": "usage-global",
+        "missingDependencies": {
+          "log": "per-file",
+          "all": true
+        }
+      }
+    ]
+  ]
+}

--- a/packages/babel-plugin-polyfill-es-shims/test/fixtures/usage-global/proposal-change-array-by-copy/output.mjs
+++ b/packages/babel-plugin-polyfill-es-shims/test/fixtures/usage-global/proposal-change-array-by-copy/output.mjs
@@ -1,0 +1,8 @@
+import "array.prototype.with/auto";
+import "array.prototype.tosorted/auto";
+import "array.prototype.toreversed/auto";
+import "array.prototype.tospliced/auto";
+arr.with(0, 3);
+arr.toSorted();
+arr.toReversed();
+arr.toSpliced(1, 1, 3, 4);

--- a/packages/babel-plugin-polyfill-es-shims/test/fixtures/usage-global/proposal-change-array-by-copy/stderr.txt
+++ b/packages/babel-plugin-polyfill-es-shims/test/fixtures/usage-global/proposal-change-array-by-copy/stderr.txt
@@ -1,0 +1,4 @@
+Some polyfills have been added but are not present in your dependencies.
+Please run one of the following commands:
+	npm install --save array.prototype.toreversed@^1.0.1 array.prototype.tosorted@^1.0.0 array.prototype.tospliced@^1.0.0 array.prototype.with@^1.0.1
+	yarn add array.prototype.toreversed@^1.0.1 array.prototype.tosorted@^1.0.0 array.prototype.tospliced@^1.0.0 array.prototype.with@^1.0.1

--- a/packages/babel-plugin-polyfill-es-shims/test/fixtures/usage-pure/proposal-change-array-by-copy/input.mjs
+++ b/packages/babel-plugin-polyfill-es-shims/test/fixtures/usage-pure/proposal-change-array-by-copy/input.mjs
@@ -1,0 +1,9 @@
+[3, 1, 2].with(0, 3);
+[3, 1, 2].toSorted();
+[3, 1, 2].toReversed();
+[3, 1, 2].toSpliced(1, 1, 3, 4);
+
+arr.with(0, 3);
+arr.toSorted();
+arr.toReversed();
+arr.toSpliced(1, 1, 3, 4);

--- a/packages/babel-plugin-polyfill-es-shims/test/fixtures/usage-pure/proposal-change-array-by-copy/options.json
+++ b/packages/babel-plugin-polyfill-es-shims/test/fixtures/usage-pure/proposal-change-array-by-copy/options.json
@@ -1,0 +1,15 @@
+{
+  "validateLogs": true,
+  "plugins": [
+    [
+      "@@/polyfill-es-shims",
+      {
+        "method": "usage-pure",
+        "missingDependencies": {
+          "log": "per-file",
+          "all": true
+        }
+      }
+    ]
+  ]
+}

--- a/packages/babel-plugin-polyfill-es-shims/test/fixtures/usage-pure/proposal-change-array-by-copy/output.mjs
+++ b/packages/babel-plugin-polyfill-es-shims/test/fixtures/usage-pure/proposal-change-array-by-copy/output.mjs
@@ -1,0 +1,19 @@
+var _arr, _arr2, _arr3, _arr4;
+
+import _ArrayPrototypeWith from "array.prototype.with";
+import _ArrayPrototypeToSorted from "array.prototype.tosorted";
+import _ArrayPrototypeToReversed from "array.prototype.toreversed";
+import _ArrayPrototypeToSpliced from "array.prototype.tospliced";
+
+_ArrayPrototypeWith([3, 1, 2], 0, 3);
+
+_ArrayPrototypeToSorted([3, 1, 2]);
+
+_ArrayPrototypeToReversed([3, 1, 2]);
+
+_ArrayPrototypeToSpliced([3, 1, 2], 1, 1, 3, 4);
+
+(_arr = arr, Array.isArray(_arr) ? _ArrayPrototypeWith : Function.call.bind(_arr.with))(_arr, 0, 3);
+(_arr2 = arr, Array.isArray(_arr2) ? _ArrayPrototypeToSorted : Function.call.bind(_arr2.toSorted))(_arr2);
+(_arr3 = arr, Array.isArray(_arr3) ? _ArrayPrototypeToReversed : Function.call.bind(_arr3.toReversed))(_arr3);
+(_arr4 = arr, Array.isArray(_arr4) ? _ArrayPrototypeToSpliced : Function.call.bind(_arr4.toSpliced))(_arr4, 1, 1, 3, 4);

--- a/packages/babel-plugin-polyfill-es-shims/test/fixtures/usage-pure/proposal-change-array-by-copy/stderr.txt
+++ b/packages/babel-plugin-polyfill-es-shims/test/fixtures/usage-pure/proposal-change-array-by-copy/stderr.txt
@@ -1,0 +1,4 @@
+Some polyfills have been added but are not present in your dependencies.
+Please run one of the following commands:
+	npm install --save array.prototype.toreversed@^1.0.1 array.prototype.tosorted@^1.0.0 array.prototype.tospliced@^1.0.0 array.prototype.with@^1.0.1
+	yarn add array.prototype.toreversed@^1.0.1 array.prototype.tosorted@^1.0.0 array.prototype.tospliced@^1.0.0 array.prototype.with@^1.0.1

--- a/scripts/build-es-shims-data/es-shims-features.js
+++ b/scripts/build-es-shims-data/es-shims-features.js
@@ -30,7 +30,11 @@ module.exports = {
   "Array.prototype.reduce": "Array methods / Array.prototype.reduce",
   "Array.prototype.reduceRight": "Array methods / Array.prototype.reduceRight",
   "Array.prototype.some": "Array methods / Array.prototype.some",
+  //"Array.prototype.toReversed": MISSING,
+  //"Array.prototype.toSpliced": MISSING,
+  //"Array.prototype.toSorted": MISSING,
   "Array.prototype.values": "Array.prototype methods / Array.prototype.values",
+  //"Array.prototype.with": MISSING,
   "Error cause": "Error.cause property",
   "Function.prototype.name": {
     features: [

--- a/scripts/build-es-shims-data/index.js
+++ b/scripts/build-es-shims-data/index.js
@@ -5,6 +5,19 @@ const path = require("path");
 const { generateData, environments, writeFile } = require("./utils-build-data");
 
 const newData = generateData(environments, require(`./es-shims-features`));
+
+// These features are missing from compat-table. Remove this from this list once they are added.
+const missing = [
+  "Array.prototype.toReversed",
+  "Array.prototype.toSorted",
+  "Array.prototype.toSpliced",
+  "Array.prototype.with",
+];
+for (const name of missing) {
+  if (newData[name]) throw new Error(`Missing feature is present: ${name}`);
+  newData[name] = {};
+}
+
 const dataPath = path.join(
   __dirname,
   `../../packages/babel-plugin-polyfill-es-shims/data/polyfills.json`


### PR DESCRIPTION
I also added `findLast`/`findLastIndex` to the readme, because they have been supported since #94.

I didn't add the group-by proposal yet, to wait for the new name.