### PR TITLE
Include es.promise.finally in PromiseDependencies

### DIFF
--- a/packages/babel-plugin-polyfill-corejs3/src/built-in-definitions.ts
+++ b/packages/babel-plugin-polyfill-corejs3/src/built-in-definitions.ts
@@ -86,7 +86,7 @@ const TypedArrayDependencies = [
   "esnext.typed-array.with",
 ];
 
-export const PromiseDependencies = ["es.promise", "es.object.to-string"];
+export const PromiseDependencies = ["es.promise", "es.promise.finally", "es.object.to-string"];
 
 export const PromiseDependenciesWithIterators = [
   ...PromiseDependencies,
@@ -678,7 +678,7 @@ export const InstanceProperties = {
     ...IteratorDependencies,
   ]),
   filterReject: define("instance/filterReject", ["esnext.array.filter-reject"]),
-  finally: define(null, ["es.promise.finally", ...PromiseDependencies]),
+  finally: define(null, PromiseDependencies),
   find: define("instance/find", [
     "es.array.find",
     "esnext.async-iterator.find",


### PR DESCRIPTION
Include es.promise.finally in PromiseDependencies, so it is correctly loaded when the native Promise constructor is overwritten.

context:
Version 3.24.0 of CoreJS changed how the loading of the Promise constructor shim behaves in NodeJS environments, causing it to overwrite the native Promise constructor when JSDom is loaded (e.g. with Jest), because JSDom tries to emulate a browser but misses the global PromiseRejectionEvent. I would agree with the author that this is correct behavior from a core-js point of view (https://github.com/zloirock/core-js/issues/1110#issuecomment-1194181863). However, this means that when using babel-polyfills, the new Promise is missing a `finally` method, because it is not listed as one of the PromiseDependencies, causing 3rd party code that is not run through Babel to break.

Although this is how the problem occurs to me, I don't think this problem is JSDom-specific. It could occur in any browser that has a non-compliant native Promise implementation.

This PR adds es.promise.finally to the PromiseDependencies, so it always gets loaded when Promises are used, and not just when the finally method is used in transformed code