### PR TITLE
fix: CI fails on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,8 @@ jobs:
       - name: Build
         run: yarn build
       - name: Test on Node.js ${{ matrix.node-version }}
-        run: yarn jest --ci --color
+        # `maxWorkers` cannot be 1 because we are using `process.exitCode` in our tests.
+        run: yarn jest --ci --color --maxWorkers=2
         env:
           BABEL_TYPES_8_BREAKING: true
       - name: Test the esm build
@@ -90,7 +91,8 @@ jobs:
       - name: Build
         run: yarn build-corejs3-shipped-proposals && gulp build && gulp bundle
       - name: Test on Node.js latest
-        run: yarn jest --ci --color
+        # `maxWorkers` cannot be 1 because we are using `process.exitCode` in our tests.
+        run: yarn jest --ci --color --maxWorkers=2
         env:
           BABEL_TYPES_8_BREAKING: true
       - name: Test the esm build


### PR DESCRIPTION
ref: https://github.com/babel/babel-polyfills/pull/149#issuecomment-1369003357

I don't know why it suddenly fails without any changes (I can't reproduce it locally.), but I should have found the reason.
jest's default maxWorkers==1 in CI (cpu ==2), which means that there is no complete isolation test.
https://github.com/babel/babel-polyfills/blob/798db9d4b3e3096fd6fc5b48c2fedd78e948b6b8/packages/babel-helper-define-polyfill-provider/src/node/dependencies.ts#L71
