### PR TITLE
(corejs3): fixed dot-all/sticky definitions

### DIFF
--- a/packages/babel-plugin-polyfill-corejs3/src/built-in-definitions.ts
+++ b/packages/babel-plugin-polyfill-corejs3/src/built-in-definitions.ts
@@ -683,7 +683,7 @@ export const InstanceProperties = {
   concat: define("instance/concat", ["es.array.concat"], undefined, ["String"]),
   copyWithin: define("instance/copy-within", ["es.array.copy-within"]),
   description: define(null, ["es.symbol", "es.symbol.description"]),
-  dotAll: define("regexp/dot-all", ["es.regexp.dot-all"]),
+  dotAll: define(null, ["es.regexp.dot-all"]),
   drop: define("instance/drop", [
     "esnext.async-iterator.drop",
     ...AsyncIteratorDependencies,
@@ -824,7 +824,7 @@ export const InstanceProperties = {
   splice: define("instance/splice", ["es.array.splice"]),
   split: define(null, ["es.string.split", "es.regexp.exec"]),
   startsWith: define("instance/starts-with", ["es.string.starts-with"]),
-  sticky: define("regexp/sticky", ["es.regexp.sticky"]),
+  sticky: define(null, ["es.regexp.sticky"]),
   strike: define(null, ["es.string.strike"]),
   sub: define(null, ["es.string.sub"]),
   substr: define(null, ["es.string.substr"]),

--- a/packages/babel-plugin-polyfill-corejs3/src/built-in-definitions.ts
+++ b/packages/babel-plugin-polyfill-corejs3/src/built-in-definitions.ts
@@ -683,7 +683,7 @@ export const InstanceProperties = {
   concat: define("instance/concat", ["es.array.concat"], undefined, ["String"]),
   copyWithin: define("instance/copy-within", ["es.array.copy-within"]),
   description: define(null, ["es.symbol", "es.symbol.description"]),
-  dotAll: define("instance/dot-all", ["es.regexp.dot-all"]),
+  dotAll: define("regexp/dot-all", ["es.regexp.dot-all"]),
   drop: define("instance/drop", [
     "esnext.async-iterator.drop",
     ...AsyncIteratorDependencies,
@@ -824,7 +824,7 @@ export const InstanceProperties = {
   splice: define("instance/splice", ["es.array.splice"]),
   split: define(null, ["es.string.split", "es.regexp.exec"]),
   startsWith: define("instance/starts-with", ["es.string.starts-with"]),
-  sticky: define("instance/sticky", ["es.regexp.sticky"]),
+  sticky: define("regexp/sticky", ["es.regexp.sticky"]),
   strike: define(null, ["es.string.strike"]),
   sub: define(null, ["es.string.sub"]),
   substr: define(null, ["es.string.substr"]),

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-pure/all-corejs-3.21/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-pure/all-corejs-3.21/output.mjs
@@ -6,8 +6,6 @@ import _forEachInstanceProperty from "core-js-pure/stable/instance/for-each.js";
 import _mapInstanceProperty from "core-js-pure/stable/instance/map.js";
 import _filterInstanceProperty from "core-js-pure/stable/instance/filter.js";
 import _Map from "core-js-pure/stable/map/index.js";
-import _dotAllInstanceProperty from "core-js-pure/stable/instance/dot-all.js";
-import _stickyInstanceProperty from "core-js-pure/stable/instance/sticky.js";
 import _Symbol from "core-js-pure/stable/symbol/index.js";
 import _Symbol$matchAll from "core-js-pure/stable/symbol/match-all.js";
 import _replaceAllInstanceProperty from "core-js-pure/stable/instance/replace-all.js";
@@ -39,11 +37,8 @@ new _Map([['x', 1]]).emplace('x', {
   update: x => x + 1,
   insert: () => 0
 });
-
-_dotAllInstanceProperty(/x/);
-
-_stickyInstanceProperty(/x/);
-
+/x/.dotAll;
+/x/.sticky;
 _Symbol.asyncDispose;
 _Symbol.matcher;
 _Symbol$matchAll;

--- a/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-pure/all-proposals-corejs-3.20/output.mjs
+++ b/packages/babel-plugin-polyfill-corejs3/test/fixtures/usage-pure/all-proposals-corejs-3.20/output.mjs
@@ -18,8 +18,6 @@ import _BigInt$range from "core-js-pure/features/bigint/range.js";
 import _Array$isTemplateObject from "core-js-pure/features/array/is-template-object.js";
 import _emplaceInstanceProperty from "core-js-pure/features/instance/emplace.js";
 import _Map from "core-js-pure/features/map/index.js";
-import _dotAllInstanceProperty from "core-js-pure/features/instance/dot-all.js";
-import _stickyInstanceProperty from "core-js-pure/features/instance/sticky.js";
 import _Symbol$asyncDispose from "core-js-pure/features/symbol/async-dispose.js";
 import _Symbol$matcher from "core-js-pure/features/symbol/matcher.js";
 import _Symbol$matchAll from "core-js-pure/features/symbol/match-all.js";
@@ -62,10 +60,8 @@ _emplaceInstanceProperty(_context14 = new _Map([['x', 1]])).call(_context14, 'x'
   insert: () => 0
 });
 
-_dotAllInstanceProperty(/x/);
-
-_stickyInstanceProperty(/x/);
-
+/x/.dotAll;
+/x/.sticky;
 _Symbol$asyncDispose;
 _Symbol$matcher;
 _Symbol$matchAll;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10938,9 +10938,9 @@ fsevents@^1.2.7:
   linkType: hard
 
 "node-releases@npm:^2.0.6":
-  version: 2.0.6
-  resolution: "node-releases@npm:2.0.6"
-  checksum: e86a926dc9fbb3b41b4c4a89d998afdf140e20a4e8dbe6c0a807f7b2948b42ea97d7fd3ad4868041487b6e9ee98409829c6e4d84a734a4215dff060a7fbeb4bf
+  version: 2.0.8
+  resolution: "node-releases@npm:2.0.8"
+  checksum: b1ab02c0d5d8e081bf9537232777a7a787dc8fef07f70feabe70a344599b220fe16462f746ac30f3eed5a58549445ad69368964d12a1f8b3b764f6caab7ba34a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes https://github.com/babel/babel-polyfills/issues/152.

Here they are:

- https://unpkg.com/browse/core-js-pure@3.27.2/stable/regexp/dot-all.js
- https://unpkg.com/browse/core-js-pure@3.27.2/stable/regexp/sticky.js