### PR TITLE
[corejs2] Fix import of the symbol pure polyfill

### DIFF
--- a/packages/babel-plugin-polyfill-corejs2/src/built-in-definitions.ts
+++ b/packages/babel-plugin-polyfill-corejs2/src/built-in-definitions.ts
@@ -56,7 +56,7 @@ export const BuiltIns: ObjectMap<PolyfillDescriptor<CoreJS2Meta>> = {
   Promise: pureAndGlobal("promise", PromiseDependencies),
   RegExp: globalOnly(["es6.regexp.constructor"]),
   Set: pureAndGlobal("set", ["es6.set", ...CommonIterators]),
-  Symbol: pureAndGlobal("symbol", ["es6.symbol"]),
+  Symbol: pureAndGlobal("symbol/index", ["es6.symbol"]),
   Uint8Array: globalOnly(["es6.typed.uint8-array"]),
   Uint8ClampedArray: globalOnly(["es6.typed.uint8-clamped-array"]),
   Uint16Array: globalOnly(["es6.typed.uint16-array"]),

--- a/packages/babel-plugin-polyfill-corejs2/test/fixtures/usage-pure/aliased-constructors/output.js
+++ b/packages/babel-plugin-polyfill-corejs2/test/fixtures/usage-pure/aliased-constructors/output.js
@@ -1,6 +1,6 @@
 var _Promise = require("core-js/library/fn/promise.js");
 
-var _Symbol = require("core-js/library/fn/symbol.js");
+var _Symbol = require("core-js/library/fn/symbol/index.js");
 
 var _Map = require("core-js/library/fn/map.js");
 

--- a/packages/babel-plugin-polyfill-corejs2/test/fixtures/usage-pure/built-in-globals/output.js
+++ b/packages/babel-plugin-polyfill-corejs2/test/fixtures/usage-pure/built-in-globals/output.js
@@ -4,7 +4,7 @@ var _Promise = require("core-js/library/fn/promise.js");
 
 var _Set = require("core-js/library/fn/set.js");
 
-var _Symbol = require("core-js/library/fn/symbol.js");
+var _Symbol = require("core-js/library/fn/symbol/index.js");
 
 var _WeakMap = require("core-js/library/fn/weak-map.js");
 

--- a/packages/babel-plugin-polyfill-corejs2/test/fixtures/usage-pure/built-in-static-methods/output.js
+++ b/packages/babel-plugin-polyfill-corejs2/test/fixtures/usage-pure/built-in-static-methods/output.js
@@ -96,7 +96,7 @@ var _String$fromCodePoint = require("core-js/library/fn/string/from-code-point.j
 
 var _String$raw = require("core-js/library/fn/string/raw.js");
 
-var _Symbol = require("core-js/library/fn/symbol.js");
+var _Symbol = require("core-js/library/fn/symbol/index.js");
 
 var _Symbol$for = require("core-js/library/fn/symbol/for.js");
 

--- a/packages/babel-plugin-polyfill-corejs2/test/fixtures/usage-pure/es6-for-of/output.js
+++ b/packages/babel-plugin-polyfill-corejs2/test/fixtures/usage-pure/es6-for-of/output.js
@@ -1,6 +1,6 @@
 var _Array$from = require("core-js/library/fn/array/from.js");
 
-var _Symbol = require("core-js/library/fn/symbol.js");
+var _Symbol = require("core-js/library/fn/symbol/index.js");
 
 var _Symbol$iterator = require("core-js/library/fn/symbol/iterator.js");
 


### PR DESCRIPTION
`symbol.js` in https://unpkg.com/browse/core-js@2.6.12/library/fn/ doesn't exist, so we have to use `symbol/index.js`. All the other pure polyfills for globals that we inject have the `<name>.js` file; this is the only exception.