### PR TITLE
Use forked `semver@6` with backported security fixes

### DIFF
--- a/lib/semver.d.ts
+++ b/lib/semver.d.ts
@@ -1,0 +1,4 @@
+declare module "@nicolo-ribaudo/semver-v6" {
+  export { default } from "./semver";
+  export * from "./semver";
+}

--- a/packages/babel-helper-define-polyfill-provider/package.json
+++ b/packages/babel-helper-define-polyfill-provider/package.json
@@ -37,8 +37,7 @@
     "@babel/helper-plugin-utils": "^7.16.7",
     "debug": "^4.1.1",
     "lodash.debounce": "^4.0.8",
-    "resolve": "^1.14.2",
-    "semver": "^6.1.2"
+    "resolve": "^1.14.2"
   },
   "peerDependencies": {
     "@babel/core": "^7.4.0-0"

--- a/packages/babel-plugin-polyfill-corejs2/package.json
+++ b/packages/babel-plugin-polyfill-corejs2/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@babel/compat-data": "^7.17.7",
     "@babel/helper-define-polyfill-provider": "workspace:^0.4.0",
-    "semver": "^6.1.1"
+    "@nicolo-ribaudo/semver-v6": "^6.3.3"
   },
   "devDependencies": {
     "@babel/core": "^7.17.8",

--- a/packages/babel-plugin-polyfill-corejs2/src/helpers.ts
+++ b/packages/babel-plugin-polyfill-corejs2/src/helpers.ts
@@ -1,4 +1,6 @@
-import semver from "semver";
+/// <reference path="../../../lib/semver.d.ts" />
+
+import semver from "@nicolo-ribaudo/semver-v6";
 
 export function hasMinVersion(
   minVersion?: string | null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2750,6 +2750,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nicolo-ribaudo/semver-v6@npm:^6.3.3":
+  version: 6.3.3
+  resolution: "@nicolo-ribaudo/semver-v6@npm:6.3.3"
+  bin:
+    semver: bin/semver.js
+  checksum: 8290855b1591477d2298364541fda64fafd4acc110b387067a71c9b05f4105c0a4ac079857ae9cd107c42ee884e8724a406b5116f069575e02d7ab87a35a5272
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -4312,7 +4321,7 @@ __metadata:
     "@babel/helper-plugin-test-runner": ^7.16.7
     "@babel/plugin-transform-for-of": ^7.16.7
     "@babel/plugin-transform-modules-commonjs": ^7.17.7
-    semver: ^6.1.1
+    "@nicolo-ribaudo/semver-v6": ^6.3.3
   peerDependencies:
     "@babel/core": ^7.0.0-0
   languageName: unknown


### PR DESCRIPTION
Hi,

For consistency purpose (and to get rid of warnings, I should admit), I think this project must use the newly backport forked of `node-semver`. I shamely just adapted the fix made by @nicolo-ribaudo on the main repo.