### PR TITLE
Replace lodash with es-toolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "gulp-watch": "^5.0.1",
     "jest": "^27.5.1",
     "lerna": "^3.22.1",
-    "lodash": "^4.17.21",
     "prettier": "^3.6.2",
     "rimraf": "^2.7.1",
     "rollup": "^2.79.2",
@@ -93,5 +92,8 @@
     }
   },
   "version": "0.0.0",
-  "packageManager": "yarn@4.9.2"
+  "packageManager": "yarn@4.9.2",
+  "dependencies": {
+    "es-toolkit": "^1.39.5"
+  }
 }

--- a/packages/babel-helper-define-polyfill-provider/package.json
+++ b/packages/babel-helper-define-polyfill-provider/package.json
@@ -36,7 +36,7 @@
     "@babel/helper-compilation-targets": "^7.27.2",
     "@babel/helper-plugin-utils": "^7.27.1",
     "debug": "^4.4.1",
-    "lodash.debounce": "^4.0.8",
+    "es-toolkit": "^1.39.5",
     "resolve": "^1.22.10"
   },
   "peerDependencies": {

--- a/packages/babel-helper-define-polyfill-provider/src/node/dependencies.ts
+++ b/packages/babel-helper-define-polyfill-provider/src/node/dependencies.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import debounce from "lodash.debounce";
+import debounce from "es-toolkit/compat/debounce";
 import requireResolve from "resolve";
 
 const nativeRequireResolve = parseFloat(process.versions.node) >= 8.9;

--- a/scripts/build-es-shims-data/utils-build-data.js
+++ b/scripts/build-es-shims-data/utils-build-data.js
@@ -3,9 +3,9 @@
 "use strict";
 
 const fs = require("fs");
-const flatMap = require("lodash/flatMap");
-const mapValues = require("lodash/mapValues");
-const findLastIndex = require("lodash/findLastIndex");
+const flatMap = require("es-toolkit/compat/flatMap");
+const mapValues = require("es-toolkit/compat/mapValues");
+const findLastIndex = require("es-toolkit/compat/findLastIndex");
 const electronToChromiumVersions = require("electron-to-chromium").versions;
 
 const envs = require("../../build/compat-table/environments");

--- a/yarn.lock
+++ b/yarn.lock
@@ -214,7 +214,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-define-polyfill-provider@workspace:^0.6.4, @babel/helper-define-polyfill-provider@workspace:packages/babel-helper-define-polyfill-provider":
+"@babel/helper-define-polyfill-provider@workspace:^0.6.5, @babel/helper-define-polyfill-provider@workspace:packages/babel-helper-define-polyfill-provider":
   version: 0.0.0-use.local
   resolution: "@babel/helper-define-polyfill-provider@workspace:packages/babel-helper-define-polyfill-provider"
   dependencies:
@@ -227,7 +227,7 @@ __metadata:
     "@babel/traverse": "npm:^7.27.7"
     babel-loader: "npm:^8.4.1"
     debug: "npm:^4.4.1"
-    lodash.debounce: "npm:^4.0.8"
+    es-toolkit: "npm:^1.39.5"
     resolve: "npm:^1.22.10"
     rollup: "npm:^2.79.2"
     rollup-plugin-babel: "npm:^4.4.0"
@@ -4506,7 +4506,7 @@ __metadata:
   dependencies:
     "@babel/compat-data": "npm:^7.27.7"
     "@babel/core": "npm:^7.27.7"
-    "@babel/helper-define-polyfill-provider": "workspace:^0.6.4"
+    "@babel/helper-define-polyfill-provider": "workspace:^0.6.5"
     "@babel/helper-plugin-test-runner": "npm:^7.27.1"
     "@babel/plugin-transform-for-of": "npm:^7.27.1"
     "@babel/plugin-transform-modules-commonjs": "npm:^7.27.1"
@@ -4533,7 +4533,7 @@ __metadata:
   resolution: "babel-plugin-polyfill-corejs3@workspace:packages/babel-plugin-polyfill-corejs3"
   dependencies:
     "@babel/core": "npm:^7.27.7"
-    "@babel/helper-define-polyfill-provider": "workspace:^0.6.4"
+    "@babel/helper-define-polyfill-provider": "workspace:^0.6.5"
     "@babel/helper-plugin-test-runner": "npm:^7.27.1"
     "@babel/plugin-proposal-decorators": "npm:^7.27.1"
     "@babel/plugin-transform-class-properties": "npm:^7.27.1"
@@ -4555,7 +4555,7 @@ __metadata:
   resolution: "babel-plugin-polyfill-es-shims@workspace:packages/babel-plugin-polyfill-es-shims"
   dependencies:
     "@babel/core": "npm:^7.27.7"
-    "@babel/helper-define-polyfill-provider": "workspace:^0.6.4"
+    "@babel/helper-define-polyfill-provider": "workspace:^0.6.5"
     "@babel/helper-plugin-test-runner": "npm:^7.27.1"
     array.from: "npm:^1.1.6"
     math.clz32: "npm:^1.0.3"
@@ -4580,7 +4580,7 @@ __metadata:
   resolution: "babel-plugin-polyfill-regenerator@workspace:packages/babel-plugin-polyfill-regenerator"
   dependencies:
     "@babel/core": "npm:^7.27.7"
-    "@babel/helper-define-polyfill-provider": "workspace:^0.6.4"
+    "@babel/helper-define-polyfill-provider": "workspace:^0.6.5"
     "@babel/helper-plugin-test-runner": "npm:^7.27.1"
     "@babel/plugin-transform-regenerator": "npm:~7.14.5"
     regenerator-runtime: "npm:^0.14.1"
@@ -4610,6 +4610,7 @@ __metadata:
     babel-jest: "npm:^29.7.0"
     chalk: "npm:^3.0.0"
     electron-to-chromium: "npm:^1.5.177"
+    es-toolkit: "npm:^1.39.5"
     eslint: "npm:^8.57.1"
     eslint-formatter-codeframe: "npm:^7.32.1"
     eslint-plugin-import: "npm:^2.32.0"
@@ -4624,7 +4625,6 @@ __metadata:
     gulp-watch: "npm:^5.0.1"
     jest: "npm:^27.5.1"
     lerna: "npm:^3.22.1"
-    lodash: "npm:^4.17.21"
     prettier: "npm:^3.6.2"
     rimraf: "npm:^2.7.1"
     rollup: "npm:^2.79.2"
@@ -6687,6 +6687,18 @@ __metadata:
     is-date-object: "npm:^1.0.5"
     is-symbol: "npm:^1.0.4"
   checksum: 10/17faf35c221aad59a16286cbf58ef6f080bf3c485dff202c490d074d8e74da07884e29b852c245d894eac84f73c58330ec956dfd6d02c0b449d75eb1012a3f9b
+  languageName: node
+  linkType: hard
+
+"es-toolkit@npm:^1.39.5":
+  version: 1.39.5
+  resolution: "es-toolkit@npm:1.39.5"
+  dependenciesMeta:
+    "@trivago/prettier-plugin-sort-imports@4.3.0":
+      unplugged: true
+    prettier-plugin-sort-re-exports@0.0.1:
+      unplugged: true
+  checksum: 10/3b7e7d5bd50b8e603fbde93149d90ae541c1fc804b516d3b22f3d107724fb0b8f91bc4a17ca6af3bd17c8e5be89f1a7ec673a3e7f8a55323704a31e77cc5fa67
   languageName: node
   linkType: hard
 
@@ -10739,7 +10751,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.12, lodash@npm:^4.17.15, lodash@npm:^4.17.21, lodash@npm:^4.2.1, lodash@npm:^4.7.0":
+"lodash@npm:^4.17.12, lodash@npm:^4.17.15, lodash@npm:^4.2.1, lodash@npm:^4.7.0":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: 10/c08619c038846ea6ac754abd6dd29d2568aa705feb69339e836dfa8d8b09abbb2f859371e86863eda41848221f9af43714491467b5b0299122431e202bb0c532


### PR DESCRIPTION
## Replace lodash with es-toolkit for reduced bundle size

### Summary
This PR replaces `lodash.debounce` dependency in `babel-helper-define-polyfill-provider` and `lodash` in build scripts with `es-toolkit`, achieving significant bundle size reduction while maintaining full compatibility.

### Changes
- **babel-helper-define-polyfill-provider**: Replaced `lodash.debounce` with `es-toolkit/debounce`
- **Build scripts**: Replaced `lodash` with `es-toolkit`

### Benefits
- **Bundle size reduction**: debounce function code reduced from 378 lines to 110 lines (~3x smaller)
- **Cleaner implementation**: es-toolkit removes unnecessary utilities like `toNumber`, `isSymbol`, etc., keeping only the essential logic needed for most use cases
- **Zero breaking changes**: Build output diff shows identical results except for the migration itself
- **Full compatibility**: es-toolkit/compat passes all lodash test cases and maintains 100% interface compatibility

### Performance Impact
While debounce functions don't typically have significant performance implications, the substantial bundle size reduction (3x smaller) provides clear value for end users.

### Testing
- ✅ All existing tests pass
- ✅ Build output verification shows identical results

  - <img width="1004" alt="Screenshot 2025-07-02 at 12 07 55 AM" src="https://github.com/user-attachments/assets/99cb631f-4beb-4c1e-bb64-997fbcce038f" />

- ✅ es-toolkit/compat compatibility confirmed through lodash test suite

### Migration Details
The migration maintains the exact same API surface, ensuring this is a drop-in replacement with no changes required for consumers of this package.
