### PR TITLE
[deps] update `resolve`

### DIFF
--- a/packages/babel-helper-define-polyfill-provider/package.json
+++ b/packages/babel-helper-define-polyfill-provider/package.json
@@ -37,7 +37,7 @@
     "@babel/helper-plugin-utils": "^7.28.6",
     "debug": "^4.4.3",
     "lodash.debounce": "^4.0.8",
-    "resolve": "^1.22.11"
+    "resolve": "^2.0.0-next.6"
   },
   "peerDependencies": {
     "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"


### PR DESCRIPTION
This updates to resolve@next, which for this package's uses is a nonbreaking update.

What this allows in the future, however, is `exports`-aware resolution.