### PR TITLE
Avoid infinite recursion in `resolveSource`

### DIFF
--- a/packages/babel-helper-define-polyfill-provider/src/utils.ts
+++ b/packages/babel-helper-define-polyfill-provider/src/utils.ts
@@ -22,20 +22,20 @@ export function has(object: any, key: string) {
 
 function resolve(
   path: NodePath,
-  resolved: Set<NodePath> = new Set(),
+  seen: Set<NodePath> = new Set(),
 ): NodePath | undefined {
-  if (resolved.has(path)) return;
-  resolved.add(path);
+  if (seen.has(path)) return;
+  seen.add(path);
 
   if (path.isVariableDeclarator()) {
     if (path.get("id").isIdentifier()) {
-      return resolve(path.get("init"), resolved);
+      return resolve(path.get("init"), seen);
     }
   } else if (path.isReferencedIdentifier()) {
     const binding = path.scope.getBinding(path.node.name);
     if (!binding) return path;
     if (!binding.constant) return;
-    return resolve(binding.path, resolved);
+    return resolve(binding.path, seen);
   }
   return path;
 }
@@ -104,15 +104,23 @@ export function resolveKey(
   }
 }
 
-export function resolveInstance(obj: NodePath): string | null {
-  const source = resolveSource(obj);
+function resolveInstance(obj: NodePath, seen: Set<NodePath>): string | null {
+  const source = resolveSource(obj, seen);
   return source.placement === "prototype" ? source.id : null;
 }
 
-export function resolveSource(obj: NodePath): {
+export function resolveSource(
+  obj: NodePath,
+  seen: Set<NodePath>,
+): {
   id: string | null;
   placement: "prototype" | "static" | null;
 } {
+  if (seen.has(obj)) {
+    return { id: null, placement: null };
+  }
+  seen.add(obj);
+
   if (
     obj.isMemberExpression() &&
     obj.get("property").isIdentifier({ name: "prototype" })
@@ -175,6 +183,7 @@ export function resolveSource(obj: NodePath): {
       if (operator === "-" || operator === "~") {
         const arg = resolveInstance(
           (path as NodePath<t.UnaryExpression>).get("argument"),
+          seen,
         );
         if (arg === "BigInt") return { id: "BigInt", placement: "prototype" };
         if (arg !== null) return { id: "Number", placement: "prototype" };
@@ -186,6 +195,7 @@ export function resolveSource(obj: NodePath): {
     case "UpdateExpression": {
       const arg = resolveInstance(
         (path as NodePath<t.UpdateExpression>).get("argument"),
+        seen,
       );
       if (arg === "BigInt") return { id: "BigInt", placement: "prototype" };
       if (arg !== null) return { id: "Number", placement: "prototype" };
@@ -227,9 +237,11 @@ export function resolveSource(obj: NodePath): {
       ) {
         const left = resolveInstance(
           (path as NodePath<t.BinaryExpression>).get("left"),
+          seen,
         );
         const right = resolveInstance(
           (path as NodePath<t.BinaryExpression>).get("right"),
+          seen,
         );
         if (left === "BigInt" && right === "BigInt") {
           return { id: "BigInt", placement: "prototype" };
@@ -243,9 +255,11 @@ export function resolveSource(obj: NodePath): {
       if (operator === "+") {
         const left = resolveInstance(
           (path as NodePath<t.BinaryExpression>).get("left"),
+          seen,
         );
         const right = resolveInstance(
           (path as NodePath<t.BinaryExpression>).get("right"),
+          seen,
         );
         if (left === "String" || right === "String") {
           return { id: "String", placement: "prototype" };
@@ -264,13 +278,14 @@ export function resolveSource(obj: NodePath): {
       const expressions = (path as NodePath<t.SequenceExpression>).get(
         "expressions",
       );
-      return resolveSource(expressions[expressions.length - 1]);
+      return resolveSource(expressions[expressions.length - 1], seen);
     }
     // a = b -> the result is the right side
     case "AssignmentExpression": {
       if ((path.node as t.AssignmentExpression).operator === "=") {
         return resolveSource(
           (path as NodePath<t.AssignmentExpression>).get("right"),
+          seen,
         );
       }
       return { id: null, placement: null };
@@ -279,9 +294,11 @@ export function resolveSource(obj: NodePath): {
     case "ConditionalExpression": {
       const consequent = resolveSource(
         (path as NodePath<t.ConditionalExpression>).get("consequent"),
+        seen,
       );
       const alternate = resolveSource(
         (path as NodePath<t.ConditionalExpression>).get("alternate"),
+        seen,
       );
       if (consequent.id && consequent.id === alternate.id) {
         return consequent;
@@ -292,6 +309,7 @@ export function resolveSource(obj: NodePath): {
     case "ParenthesizedExpression":
       return resolveSource(
         (path as NodePath<t.ParenthesizedExpression>).get("expression"),
+        seen,
       );
     // TypeScript / Flow type wrappers -> unwrap to the inner expression
     case "TSAsExpression":
@@ -300,7 +318,7 @@ export function resolveSource(obj: NodePath): {
     case "TSInstantiationExpression":
     case "TSTypeAssertion":
     case "TypeCastExpression":
-      return resolveSource(path.get("expression") as NodePath);
+      return resolveSource(path.get("expression") as NodePath, seen);
   }
 
   return { id: null, placement: null };

--- a/packages/babel-helper-define-polyfill-provider/src/visitors/usage.ts
+++ b/packages/babel-helper-define-polyfill-provider/src/visitors/usage.ts
@@ -68,7 +68,7 @@ export default (callProvider: CallProvider) => {
         }
       }
 
-      const source = resolveSource(object);
+      const source = resolveSource(object, new Set());
       const skipObject = property(source.id, key, source.placement, path);
       const canHandleObject =
         objectIsGlobalIdentifier &&
@@ -107,7 +107,7 @@ export default (callProvider: CallProvider) => {
 
       let id = null;
       let placement = null;
-      if (obj) ({ id, placement } = resolveSource(obj));
+      if (obj) ({ id, placement } = resolveSource(obj, new Set()));
 
       for (const prop of path.get("properties")) {
         if (prop.isObjectProperty()) {
@@ -120,7 +120,7 @@ export default (callProvider: CallProvider) => {
     BinaryExpression(path: NodePath<t.BinaryExpression>) {
       if (path.node.operator !== "in") return;
 
-      const source = resolveSource(path.get("right"));
+      const source = resolveSource(path.get("right"), new Set());
       const key = resolveKey(path.get("left"), true);
 
       if (!key) return;

--- a/packages/babel-helper-define-polyfill-provider/test/descriptors.js
+++ b/packages/babel-helper-define-polyfill-provider/test/descriptors.js
@@ -895,4 +895,18 @@ describe("descriptors", () => {
       placement: null,
     });
   });
+
+  it("instance property on self-referencing variable", () => {
+    const [desc] = getDescriptor(
+      "var n = n ? n : {}; n.foo;",
+      d => d.kind === "property" && d.key === "foo",
+    );
+
+    expect(desc).toEqual({
+      kind: "property",
+      object: null,
+      key: "foo",
+      placement: null,
+    });
+  });
 });


### PR DESCRIPTION
`resolveSource` calls itself on the result of `resolve()` on its path. `resolve` can return an ancestor (if the variable references itself in its initializer), causing an infinite loop.

Adding a `seen` list fixes it.

Fixes #254